### PR TITLE
Add basic web UI and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,16 @@ This repository contains a Python project that implements the foundations of a t
 
 The current implementation is a stub and does not place real trades. It can serve as a starting point for further development.
 
-## Web Backtester
+## Web UI and API
 
-A minimal web interface is included using Python's built‑in HTTP server and [htmx](https://htmx.org/).
+A minimal web interface is included using Python's built‑in HTTP server and [htmx](https://htmx.org/). It exposes an API so you can start or stop the mock trading loop and run backtests.
 Start the server with:
 
 ```bash
 python -m vwap_option_bot.main
 ```
 
-Then open `http://127.0.0.1:8080` in your browser. Click **Run Backtest** to execute a simple backtest on sample CSV data and view the strategy signals.
+Then open `http://127.0.0.1:8080` in your browser. Use the buttons to start/stop trading or to run a backtest. The status and logs automatically refresh every few seconds.
 
 ## Contributing
 

--- a/static/index.html
+++ b/static/index.html
@@ -2,12 +2,17 @@
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>VWAP Backtester</title>
+    <title>VWAP Bot Control</title>
     <script src="https://unpkg.com/htmx.org@1.9.2"></script>
 </head>
 <body>
-    <h1>VWAP Backtester</h1>
-    <button hx-post="/backtest" hx-target="#results" hx-swap="innerHTML">Run Backtest</button>
+    <h1>VWAP Bot Control</h1>
+    <div id="status" hx-get="/api/status" hx-trigger="load, every 5s"></div>
+    <button hx-post="/api/start" hx-target="#status" hx-swap="outerHTML">Start Trading</button>
+    <button hx-post="/api/stop" hx-target="#status" hx-swap="outerHTML">Stop Trading</button>
+    <button hx-post="/api/backtest" hx-target="#results" hx-swap="innerHTML">Run Backtest</button>
     <div id="results"></div>
+    <h2>Logs</h2>
+    <div id="logs" hx-get="/api/logs" hx-trigger="load, every 5s"></div>
 </body>
 </html>

--- a/vwap_option_bot/server.py
+++ b/vwap_option_bot/server.py
@@ -1,6 +1,9 @@
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 import csv
+import json
+import threading
+import time
 
 from .models import Candle
 from .strategies import StrategyRunner
@@ -8,6 +11,10 @@ from .strategies.vwap_bounce import VwapBounce
 from .strategies.breakout import Breakout
 
 INDEX_HTML = (Path(__file__).parent / "../static/index.html").resolve().read_text()
+
+TRADING_ACTIVE = False
+TRADE_THREAD: threading.Thread | None = None
+TRADE_LOGS: list[str] = []
 
 def load_candles(path: str) -> list[Candle]:
     candles: list[Candle] = []
@@ -40,29 +47,75 @@ def run_backtest() -> list[str]:
             logs.append(f"{name} triggered at {c.timestamp}")
     return logs
 
+
+def trading_loop():
+    global TRADING_ACTIVE
+    candles = load_candles("data/sample.csv")
+    runner = StrategyRunner()
+    runner.add_strategy(VwapBounce())
+    runner.add_strategy(Breakout())
+    history: list[Candle] = []
+    for c in candles:
+        if not TRADING_ACTIVE:
+            break
+        history.append(c)
+        triggered = runner.run_on_slice(history)
+        for name in triggered:
+            msg = f"{name} triggered at {c.timestamp}"
+            TRADE_LOGS.append(msg)
+        time.sleep(0.1)
+    TRADING_ACTIVE = False
+
+
+def start_trading():
+    global TRADING_ACTIVE, TRADE_THREAD
+    if TRADING_ACTIVE:
+        return
+    TRADING_ACTIVE = True
+    TRADE_THREAD = threading.Thread(target=trading_loop, daemon=True)
+    TRADE_THREAD.start()
+
+
+def stop_trading():
+    global TRADING_ACTIVE
+    TRADING_ACTIVE = False
+
 class Handler(BaseHTTPRequestHandler):
+    def _send(self, content: bytes, content_type: str = "text/html") -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(content)))
+        self.end_headers()
+        self.wfile.write(content)
+
+    def log_message(self, format: str, *args) -> None:  # pragma: no cover
+        return
+
     def do_GET(self):
         if self.path == "/":
             content = INDEX_HTML.encode()
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html")
-            self.send_header("Content-Length", str(len(content)))
-            self.end_headers()
-            self.wfile.write(content)
+            self._send(content)
+        elif self.path == "/api/status":
+            status = json.dumps({"trading": TRADING_ACTIVE})
+            self._send(status.encode(), "application/json")
+        elif self.path == "/api/logs":
+            logs = "<br>".join(TRADE_LOGS)
+            self._send(logs.encode())
         else:
             self.send_response(404)
             self.end_headers()
             self.wfile.write(b"Not Found")
 
     def do_POST(self):
-        if self.path == "/backtest":
+        if self.path == "/api/backtest":
             results = "<br>".join(run_backtest())
-            content = results.encode()
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html")
-            self.send_header("Content-Length", str(len(content)))
-            self.end_headers()
-            self.wfile.write(content)
+            self._send(results.encode())
+        elif self.path == "/api/start":
+            start_trading()
+            self._send(b"Trading started")
+        elif self.path == "/api/stop":
+            stop_trading()
+            self._send(b"Trading stopped")
         else:
             self.send_response(404)
             self.end_headers()


### PR DESCRIPTION
## Summary
- expand `server.py` with start/stop endpoints and trading loop
- extend HTML UI with buttons for starting, stopping and backtesting
- describe the web API in the README

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_683dd1f552f48333810afbcf1621408a