### PR TITLE
Add provider factory and IB stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a Python project that implements the foundations of a t
 ## Features
 
 - Basic data classes for candles, option contracts and trade logs
-- An abstract `ExchangeApi` with a stub implementation for interacting with a broker
+- An abstract `ExchangeApi` with stub implementations and a simple factory for switching providers
 - Utility functions to calculate VWAP and detect three consecutive red candles
 - Unit tests validating the core logic
 - A step‑by‑step development plan is provided in [plan.md](plan.md)
@@ -15,7 +15,14 @@ This repository contains a Python project that implements the foundations of a t
 1. Ensure Python 3.11+ is installed.
 2. Clone this repository and navigate to its directory.
 3. Install dependencies (none are required for the core features).
-4. Run the test suite to verify the project works correctly:
+4. Use the provider factory to create a trading API instance:
+
+   ```python
+   from vwap_option_bot.exchange import get_exchange_api
+   api = get_exchange_api("alpaca")  # or "ib"
+   ```
+
+5. Run the test suite to verify the project works correctly:
 
    ```bash
    python -m unittest

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,11 +2,15 @@ import unittest
 
 from vwap_option_bot.models import Candle, OptionContract, TradeLog
 from vwap_option_bot.utils import calculate_vwap, is_three_red_candles
-from vwap_option_bot.exchange import AlpacaApiStub
+from vwap_option_bot.exchange import (
+    AlpacaApiStub,
+    InteractiveBrokersApiStub,
+    get_exchange_api,
+)
 
 class TestCore(unittest.TestCase):
     def get_api(self):
-        return AlpacaApiStub()
+        return get_exchange_api("alpaca")
 
     def test_calculate_vwap(self):
         candles = [
@@ -45,6 +49,11 @@ class TestCore(unittest.TestCase):
         api = self.get_api()
         balance = api.get_account_balance()
         self.assertEqual(balance, 10000.0)
+
+    def test_provider_switch(self):
+        api = get_exchange_api("ib")
+        self.assertIsInstance(api, InteractiveBrokersApiStub)
+        self.assertEqual(api.get_account_balance(), 50000.0)
 
     def test_get_option_chain_stub(self):
         api = self.get_api()

--- a/vwap_option_bot/exchange.py
+++ b/vwap_option_bot/exchange.py
@@ -44,3 +44,47 @@ class AlpacaApiStub(ExchangeApi):
 
     def log_trade(self, trade: TradeLog) -> None:
         pass
+
+
+class InteractiveBrokersApiStub(ExchangeApi):
+    """Minimal stub for Interactive Brokers."""
+
+    def fetch_candles(self) -> list[Candle]:
+        return []
+
+    def authenticate_broker(self) -> bool:
+        return True
+
+    def get_account_balance(self) -> float:
+        # Different starting balance to show provider distinction
+        return 50000.0
+
+    def get_option_chain(self) -> list[OptionContract]:
+        return []
+
+    def submit_order(self, contract: OptionContract, amount: float) -> bool:
+        return True
+
+    def log_trade(self, trade: TradeLog) -> None:
+        pass
+
+
+def get_exchange_api(name: str) -> ExchangeApi:
+    """Return an ExchangeApi implementation based on the provider name."""
+    providers = {
+        "alpaca": AlpacaApiStub,
+        "interactive_brokers": InteractiveBrokersApiStub,
+        "ib": InteractiveBrokersApiStub,
+    }
+    try:
+        return providers[name.lower()]()
+    except KeyError:
+        raise ValueError(f"Unknown provider '{name}'")
+
+
+__all__ = [
+    "ExchangeApi",
+    "AlpacaApiStub",
+    "InteractiveBrokersApiStub",
+    "get_exchange_api",
+]


### PR DESCRIPTION
## Summary
- add `InteractiveBrokersApiStub` and provider factory `get_exchange_api`
- document provider usage in README
- update tests to use factory and check provider switching

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e22de9ecc8333b8b2295ab0059850