### PR TITLE
Add strategy and server tests

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import patch
+
+from vwap_option_bot import server
+
+class TestServer(unittest.TestCase):
+    def test_load_candles(self):
+        candles = server.load_candles('data/sample.csv')
+        self.assertEqual(len(candles), 10)
+        self.assertEqual(candles[0].open, 100.0)
+
+    def test_run_backtest(self):
+        logs = server.run_backtest()
+        expected = [
+            'Breakout triggered at 1',
+            'VWAP Bounce triggered at 5',
+            'VWAP Bounce triggered at 6',
+            'VWAP Bounce triggered at 7',
+        ]
+        self.assertEqual(logs, expected)
+
+    def test_start_trading_creates_logs(self):
+        server.TRADE_LOGS.clear()
+        with patch('vwap_option_bot.server.time.sleep', return_value=None):
+            server.start_trading()
+            if server.TRADE_THREAD:
+                server.TRADE_THREAD.join(timeout=1.0)
+        self.assertFalse(server.TRADING_ACTIVE)
+        self.assertGreaterEqual(len(server.TRADE_LOGS), 1)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,57 @@
+import unittest
+from vwap_option_bot.models import Candle
+from vwap_option_bot.strategies import StrategyRunner
+from vwap_option_bot.strategies.vwap_bounce import VwapBounce
+from vwap_option_bot.strategies.breakout import Breakout
+
+class TestStrategies(unittest.TestCase):
+    def test_vwap_bounce_triggered(self):
+        candles = [
+            Candle(timestamp=1, open=10.0, close=9.8, high=10.2, low=9.5, volume=100.0),
+            Candle(timestamp=2, open=9.9, close=9.7, high=10.1, low=9.4, volume=100.0),
+            Candle(timestamp=3, open=9.8, close=9.6, high=10.0, low=9.3, volume=100.0),
+        ]
+        strat = VwapBounce()
+        self.assertTrue(strat.check_signal(candles))
+
+    def test_vwap_bounce_not_triggered(self):
+        candles = [
+            Candle(timestamp=1, open=10.0, close=10.1, high=10.2, low=9.8, volume=100.0),
+            Candle(timestamp=2, open=10.1, close=10.2, high=10.3, low=9.9, volume=100.0),
+            Candle(timestamp=3, open=10.2, close=10.3, high=10.4, low=10.0, volume=100.0),
+        ]
+        strat = VwapBounce()
+        self.assertFalse(strat.check_signal(candles))
+
+    def test_breakout_triggered(self):
+        candles = [
+            Candle(timestamp=1, open=10.0, close=10.0, high=10.1, low=9.9, volume=100.0),
+            Candle(timestamp=2, open=10.0, close=10.1, high=10.2, low=9.8, volume=100.0),
+            Candle(timestamp=3, open=10.1, close=10.2, high=10.3, low=9.9, volume=100.0),
+            Candle(timestamp=4, open=10.1, close=10.5, high=10.4, low=9.9, volume=100.0),
+        ]
+        strat = Breakout()
+        self.assertTrue(strat.check_signal(candles))
+
+    def test_breakout_not_triggered(self):
+        candles = [
+            Candle(timestamp=1, open=10.0, close=10.0, high=10.1, low=9.9, volume=100.0),
+            Candle(timestamp=2, open=10.0, close=10.1, high=10.2, low=9.8, volume=100.0),
+            Candle(timestamp=3, open=10.1, close=10.2, high=10.3, low=9.9, volume=100.0),
+            Candle(timestamp=4, open=10.1, close=10.25, high=10.2, low=9.9, volume=100.0),
+        ]
+        strat = Breakout()
+        self.assertFalse(strat.check_signal(candles))
+
+    def test_strategy_runner(self):
+        candles = [
+            Candle(timestamp=1, open=10.0, close=9.8, high=10.2, low=9.5, volume=100.0),
+            Candle(timestamp=2, open=9.9, close=9.7, high=10.1, low=9.4, volume=100.0),
+            Candle(timestamp=3, open=9.8, close=9.6, high=10.0, low=9.3, volume=100.0),
+        ]
+        runner = StrategyRunner()
+        runner.add_strategy(VwapBounce())
+        self.assertEqual(runner.run_on_slice(candles), ["VWAP Bounce"])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests for strategy logic and runner
- add tests for loading candles, backtesting and trade loop

## Testing
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_683e22fc5f388333a8dc533ef35fdfa1