### PR TITLE
Add deployment scaffolding

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy Bot
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Copy files to server
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          source: '.'
+          target: ${{ secrets.DEPLOY_PATH }}
+      - name: Restart service
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          script: |
+            sudo systemctl restart vwap_option_bot.service
+

--- a/README.md
+++ b/README.md
@@ -37,3 +37,10 @@ Then open `http://127.0.0.1:8080` in your browser. Use the buttons to start/stop
 ## Contributing
 
 Pull requests are welcome. Please run `python -m unittest` before submitting changes.
+
+## Deployment
+
+Example deployment files are located in the `deploy/` directory.
+These include a `systemd` service definition and a GitHub Actions
+workflow that copies the project to a VPS. Replace the placeholder
+server details with your own values before using.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Placeholder installation script for setting up the bot on a server
+# Adjust values for your environment
+set -euo pipefail
+
+BOT_DIR=/home/botuser/vwap_option_bot
+REPO_URL="https://example.com/your-repo.git"
+
+# Install system dependencies (example for Debian/Ubuntu)
+apt-get update && apt-get install -y python3 python3-venv git
+
+# Clone repository if not already present
+if [ ! -d "$BOT_DIR" ]; then
+    git clone "$REPO_URL" "$BOT_DIR"
+fi
+
+cd "$BOT_DIR"
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt || true
+
+# Copy systemd service
+cp deploy/systemd/vwap_option_bot.service /etc/systemd/system/
+
+systemctl daemon-reload
+systemctl enable vwap_option_bot.service
+systemctl start vwap_option_bot.service

--- a/deploy/systemd/vwap_option_bot.service
+++ b/deploy/systemd/vwap_option_bot.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=VWAP Option Bot Service
+After=network.target
+
+[Service]
+User=botuser
+WorkingDirectory=/home/botuser/vwap_option_bot
+ExecStart=/usr/bin/python3 -m vwap_option_bot.main
+Restart=always
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- provide example `systemd` service for running the bot
- add placeholder installation script
- document new deployment files in README
- add a GitHub Actions workflow that copies files to a VPS

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_683e22c30c888333aa14dd98f7197485