### PR TITLE
Add tRPC to frontend

### DIFF
--- a/frontend/app/api/trpc/[trpc]/route.ts
+++ b/frontend/app/api/trpc/[trpc]/route.ts
@@ -1,0 +1,12 @@
+import { appRouter } from '@/server/api/root'
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch'
+
+const handler = (req: Request) =>
+  fetchRequestHandler({
+    endpoint: '/api/trpc',
+    req,
+    router: appRouter,
+    createContext: () => ({}),
+  })
+
+export { handler as GET, handler as POST }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from "next/font/google"
 import "./globals.css"
 import { SidebarProvider } from "@/components/ui/sidebar"
 import { AppSidebar } from "@/components/app-sidebar"
+import { TRPCProvider } from "@/components/trpc-provider"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -21,10 +22,12 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <SidebarProvider>
-          <AppSidebar />
-          <main className="flex-1">{children}</main>
-        </SidebarProvider>
+        <TRPCProvider>
+          <SidebarProvider>
+            <AppSidebar />
+            <main className="flex-1">{children}</main>
+          </SidebarProvider>
+        </TRPCProvider>
       </body>
     </html>
   )

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge"
 import { SidebarTrigger } from "@/components/ui/sidebar"
 import { TrendingUp, DollarSign, Activity } from "lucide-react"
+import { Hello } from "@/components/hello"
 
 // Mock data for demonstration
 const todayStats = {
@@ -46,6 +47,7 @@ export default function Dashboard() {
           </div>
         </div>
       </header>
+      <Hello />
 
       <div className="flex-1 p-6 space-y-6">
         {/* Stats Cards */}

--- a/frontend/components/hello.tsx
+++ b/frontend/components/hello.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+import { api } from '@/lib/trpc'
+
+export function Hello() {
+  const { data, isLoading } = api.example.hello.useQuery({})
+
+  if (isLoading) return <p>Loading...</p>
+  return <p>{data?.greeting}</p>
+}

--- a/frontend/components/trpc-provider.tsx
+++ b/frontend/components/trpc-provider.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactNode, useState } from 'react'
+import { api, clientOptions } from '@/lib/trpc'
+
+export function TRPCProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient())
+  const [trpcClient] = useState(() => api.createClient(clientOptions))
+
+  return (
+    <api.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </api.Provider>
+  )
+}

--- a/frontend/lib/trpc.ts
+++ b/frontend/lib/trpc.ts
@@ -1,0 +1,29 @@
+'use client'
+
+import { createTRPCReact } from '@trpc/react-query'
+import { httpBatchLink, loggerLink } from '@trpc/client'
+import type { AppRouter } from '@/server/api/root'
+import superjson from 'superjson'
+
+export const api = createTRPCReact<AppRouter>()
+
+function getBaseUrl() {
+  if (typeof window !== 'undefined') return ''
+  return process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : 'http://localhost:3000'
+}
+
+export const clientOptions = {
+  links: [
+    loggerLink({
+      enabled: (opts) =>
+        process.env.NODE_ENV === 'development' ||
+        (opts.direction === 'down' && opts.result instanceof Error),
+    }),
+    httpBatchLink({
+      url: `${getBaseUrl()}/api/trpc`,
+    }),
+  ],
+  transformer: superjson,
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,13 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "@trpc/client": "^10.45.0",
+    "@trpc/server": "^10.45.0",
+    "@trpc/react-query": "^10.45.0",
+    "@trpc/next": "^10.45.0",
+    "@tanstack/react-query": "^5.36.0",
+    "superjson": "^1.12.2"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/frontend/server/api/root.ts
+++ b/frontend/server/api/root.ts
@@ -1,0 +1,8 @@
+import { router } from './trpc'
+import { exampleRouter } from './routers/example'
+
+export const appRouter = router({
+  example: exampleRouter,
+})
+
+export type AppRouter = typeof appRouter

--- a/frontend/server/api/routers/example.ts
+++ b/frontend/server/api/routers/example.ts
@@ -1,0 +1,10 @@
+import { router, publicProcedure } from '../trpc'
+import { z } from 'zod'
+
+export const exampleRouter = router({
+  hello: publicProcedure
+    .input(z.object({ name: z.string().optional() }))
+    .query(({ input }) => {
+      return { greeting: `Hello ${input.name ?? 'world'}` }
+    }),
+})

--- a/frontend/server/api/trpc.ts
+++ b/frontend/server/api/trpc.ts
@@ -1,0 +1,9 @@
+import { initTRPC } from '@trpc/server'
+import superjson from 'superjson'
+
+export const t = initTRPC.create({
+  transformer: superjson,
+})
+
+export const router = t.router
+export const publicProcedure = t.procedure


### PR DESCRIPTION
## Summary
- install tRPC and react-query deps
- configure tRPC server and example router
- expose tRPC via API route
- add React client utils and provider
- use provider in layout and show example in dashboard page

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_683e29aafd708333abed7a6250e5bca5