### PR TITLE
Add docker compose and startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# VWAP Option Bot Monorepo
+
+This project contains a Python backend and Next.js frontend.
+
+## Development Database
+A `docker-compose.yml` file is included to spin up a local Postgres instance.
+Run the helper script to start the database:
+
+```bash
+./scripts/start_dev.sh
+```
+
+The database will be available on `localhost:5432` with the credentials
+specified in `docker-compose.yml`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: devuser
+      POSTGRES_PASSWORD: devpass
+      POSTGRES_DB: vwap_db
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+volumes:
+  postgres-data:

--- a/scripts/start_dev.sh
+++ b/scripts/start_dev.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$(dirname "$DIR")"
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required but not installed. Please install Docker." >&2
+  exit 1
+fi
+
+echo "Starting database with Docker Compose..."
+docker compose -f "$ROOT/docker-compose.yml" up -d
+
+echo "Database is running at localhost:5432"


### PR DESCRIPTION
## Summary
- add docker-compose for a local Postgres database
- provide helper script to start the database
- document the new setup in the repo README

## Testing
- `PYTHONPATH=backend/src python -m unittest discover backend/tests` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683e38665d488333bb67e19f8f3c50b1